### PR TITLE
Fix cascader item icon alignement

### DIFF
--- a/src/styles/cascader.less
+++ b/src/styles/cascader.less
@@ -15,6 +15,17 @@
       height: 160px;
       margin-left: -1px;
 
+      li.item {
+        position: relative;
+
+        i.fa {
+            position: absolute;
+            right: 15px;
+            top: 9px;
+        }
+
+      }
+
       &:first-child {
         margin-left: 0;
       }


### PR DESCRIPTION
With this solution alignement is fixed for firefox and does not change on chrome