### PR TITLE
Slot-based Tree node content rendering

### DIFF
--- a/src/components/Tree.vue
+++ b/src/components/Tree.vue
@@ -13,6 +13,9 @@
       :on-item-dblclick="onItemDblclick"
       :on-item-remove="onItemRemove"
       :on-item-click="onItemClick">
+      <template slot-scope="item">
+        <slot v-bind="item"></slot>
+      </template>
   </fish-tree-node>
 </template>
 <script>

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -10,8 +10,7 @@
                      @click.stop="onItemChecked(item)"
                      ref="checkboxes" v-if="multiple"></fish-checkbox>
 
-      <span v-if="onItemRender"
-            class="title"
+      <span class="title"
             @click="onItemClick(item)"
             @dblclick="onItemDblclick(item)" v-html="onItemRender(item)">
       </span>

--- a/src/components/TreeNode.vue
+++ b/src/components/TreeNode.vue
@@ -9,10 +9,18 @@
                      :state="dataKeyMap[item.key][0]"
                      @click.stop="onItemChecked(item)"
                      ref="checkboxes" v-if="multiple"></fish-checkbox>
-      <span class="title"
+
+      <span v-if="onItemRender"
+            class="title"
             @click="onItemClick(item)"
             @dblclick="onItemDblclick(item)" v-html="onItemRender(item)">
       </span>
+
+
+      <slot v-bind="item"
+            @click="onItemClick(item)"
+            @dblclick="onItemDblclick(item)"></slot>
+
       <strong v-if="edited && (!item.children || item.children.length <= 0)"
               @click="itemRemoveHandler(item, index)">&times;</strong>
       <fish-tree-node
@@ -27,7 +35,9 @@
           :on-item-click="onItemClick"
           :on-item-remove="onItemRemove"
           :on-item-render="onItemRender"
-          v-if="item.children && visible[index]"></fish-tree-node>
+          v-if="item.children && visible[index]">
+          <template slot-scope="item"><slot v-bind="item"></slot></template>
+          </fish-tree-node>
     </li>
   </ul>
 </template>


### PR DESCRIPTION
Currently, we can only render static HTML as child content for FishTree nodes.

This means that we can't nest Vue components (FishUI or otherwise) inside of a FishTree.

This PR allows you to use a Vue `<slot>` to define the child node content instead of (or in addition to) `onItemRender`.

Example:
```vue
<fish-tree :data="data" :onItemRender="noop">
  <template slot-scope="item">
    <fish-button>{{ item.title }}</fish-button>
  </template>
</fish-tree>
```

