### PR TITLE
docs fixes: wrong active link & wrong page title

### DIFF
--- a/examples/components/DemoSegment.vue
+++ b/examples/components/DemoSegment.vue
@@ -1,6 +1,6 @@
 <template>
-  <main-layout>
-    <h3>Button</h3>
+  <main-layout menuActiveIndex="segment">
+    <h3>Segment</h3>
     <fish-row gutter="1">
       <fish-col span="12">
         <code-card title="Default" desc="A segment of content">


### PR DESCRIPTION
Because of not setted "menuActiveIndex" prop, active link in left bar is "button" + changed the wrong page title